### PR TITLE
Expose convenient constants for hardware register addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "paste",
  "thiserror",
  "toml",
+ "try-from-discrim",
 ]
 
 [[package]]
@@ -155,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -185,9 +186,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,6 +238,17 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "try-from-discrim"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7448782f2a418f7882a0c6dee154358b2d44566919579e5d47d71e9211de4944"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ toml = { version = "0.5.9", features = ["preserve_order"] }
 clap = { version = "3.2.17", features = ["derive"] }
 paste = "1.0.9"
 thiserror = "1.0.37"
+try-from-discrim = "1.0.0"
 
 [profile.release]
 lto = true

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -1,124 +1,169 @@
-#[allow(unused)]
-const RAMG: u16 = 0x0000;
-#[allow(unused)]
-const ROMB0: u16 = 0x2000;
-#[allow(unused)]
-const RAMB: u16 = 0x4000;
-#[allow(unused)]
-const RTCLATCH: u16 = 0x6000;
-#[allow(unused)]
-const ROMB1: u16 = 0x3000;
-#[allow(unused)]
-const P1: u16 = 0xFF00;
-#[allow(unused)]
-const SB: u16 = 0xFF01;
-#[allow(unused)]
-const SC: u16 = 0xFF02;
-#[allow(unused)]
-const DIV: u16 = 0xFF04;
-#[allow(unused)]
-const TIMA: u16 = 0xFF05;
-#[allow(unused)]
-const TMA: u16 = 0xFF06;
-#[allow(unused)]
-const TAC: u16 = 0xFF07;
-#[allow(unused)]
-const IF: u16 = 0xFF0F;
-#[allow(unused)]
-const NR10: u16 = 0xFF10;
-#[allow(unused)]
-const NR11: u16 = 0xFF11;
-#[allow(unused)]
-const NR12: u16 = 0xFF12;
-#[allow(unused)]
-const NR13: u16 = 0xFF13;
-#[allow(unused)]
-const NR14: u16 = 0xFF14;
-#[allow(unused)]
-const NR21: u16 = 0xFF16;
-#[allow(unused)]
-const NR22: u16 = 0xFF17;
-#[allow(unused)]
-const NR23: u16 = 0xFF18;
-#[allow(unused)]
-const NR24: u16 = 0xFF19;
-#[allow(unused)]
-const NR30: u16 = 0xFF1A;
-#[allow(unused)]
-const NR31: u16 = 0xFF1B;
-#[allow(unused)]
-const NR32: u16 = 0xFF1C;
-#[allow(unused)]
-const NR33: u16 = 0xFF1D;
-#[allow(unused)]
-const NR34: u16 = 0xFF1E;
-#[allow(unused)]
-const NR41: u16 = 0xFF20;
-#[allow(unused)]
-const NR42: u16 = 0xFF21;
-#[allow(unused)]
-const NR43: u16 = 0xFF22;
-#[allow(unused)]
-const NR44: u16 = 0xFF23;
-#[allow(unused)]
-const NR50: u16 = 0xFF24;
-#[allow(unused)]
-const NR51: u16 = 0xFF25;
-#[allow(unused)]
-const NR52: u16 = 0xFF26;
-#[allow(unused)]
-const LCDC: u16 = 0xFF40;
-#[allow(unused)]
-const STAT: u16 = 0xFF41;
-#[allow(unused)]
-const SCY: u16 = 0xFF42;
-#[allow(unused)]
-const SCX: u16 = 0xFF43;
-#[allow(unused)]
-const LY: u16 = 0xFF44;
-#[allow(unused)]
-const LYC: u16 = 0xFF45;
-#[allow(unused)]
-const DMA: u16 = 0xFF46;
-#[allow(unused)]
-const BGP: u16 = 0xFF47;
-#[allow(unused)]
-const OBP0: u16 = 0xFF48;
-#[allow(unused)]
-const OBP1: u16 = 0xFF49;
-#[allow(unused)]
-const WY: u16 = 0xFF4A;
-#[allow(unused)]
-const WX: u16 = 0xFF4B;
-#[allow(unused)]
-const KEY1: u16 = 0xFF4D;
-#[allow(unused)]
-const VBK: u16 = 0xFF4F;
-#[allow(unused)]
-const HDMA1: u16 = 0xFF51;
-#[allow(unused)]
-const HDMA2: u16 = 0xFF52;
-#[allow(unused)]
-const HDMA3: u16 = 0xFF53;
-#[allow(unused)]
-const HDMA4: u16 = 0xFF54;
-#[allow(unused)]
-const HDMA5: u16 = 0xFF55;
-#[allow(unused)]
-const RP: u16 = 0xFF56;
-#[allow(unused)]
-const BCPS: u16 = 0xFF68;
-#[allow(unused)]
-const BCPD: u16 = 0xFF69;
-#[allow(unused)]
-const OCPS: u16 = 0xFF6A;
-#[allow(unused)]
-const OCPD: u16 = 0xFF6B;
-#[allow(unused)]
-const SVBK: u16 = 0xFF70;
-#[allow(unused)]
-const PCM12: u16 = 0xFF76;
-#[allow(unused)]
-const PCM34: u16 = 0xFF77;
-#[allow(unused)]
-const IE: u16 = 0xFFFF;
+use try_from_discrim::TryFrom;
+
+#[derive(TryFrom)]
+#[from(u16)]
+#[non_exhaustive]
+/// A collection of hardware registers' addresses, extracted from [`hardware.inc`](https://github.com/gbdev/hardware.inc).
+pub enum HwReg {
+	/// MBC SRAM enable.
+	Ramg = 0x0000,
+	/// MBC ROM bank switch, low 8 bits.
+	Romb0 = 0x2000,
+	/// MBC ROM bank switch, upper 8 bits.
+	Romb1 = 0x3000,
+	/// MBC SRAM bank switch.
+	Ramb = 0x4000,
+	/// MBC RTC latch toggle.
+	Rtclatch = 0x6000,
+
+	/// Joypad.
+	P1 = 0xFF00,
+
+	/// Serial data.
+	Sb = 0xFF01,
+	/// Serial control.
+	Sc = 0xFF02,
+
+	/// Divided clock counter.
+	Div = 0xFF04,
+	/// Timer counter.
+	Tima = 0xFF05,
+	/// Timer modulo.
+	Tma = 0xFF06,
+	/// Timer control.
+	Tac = 0xFF07,
+
+	/// Pending interrupts.
+	If = 0xFF0F,
+
+	/// CH1 frequency sweep.
+	Nr10 = 0xFF10,
+	/// CH1 duty control & sound length.
+	Nr11 = 0xFF11,
+	/// CH1 volume control.
+	Nr12 = 0xFF12,
+	/// CH1 wavelength, low 8 bits.
+	Nr13 = 0xFF13,
+	/// CH1 wavelength, upper 3 bits & control.
+	Nr14 = 0xFF14,
+	/// CH2 duty control & sound length.
+	Nr21 = 0xFF16,
+	/// CH2 volume control.
+	Nr22 = 0xFF17,
+	/// CH2 wavelength, low 8 bits.
+	Nr23 = 0xFF18,
+	/// CH2 wavelength, upper 3 bits & control.
+	Nr24 = 0xFF19,
+	/// CH3 enable.
+	Nr30 = 0xFF1A,
+	/// CH3 sound length.
+	Nr31 = 0xFF1B,
+	/// CH3 volume control.
+	Nr32 = 0xFF1C,
+	/// CH3 wavelength, low 8 bits.
+	Nr33 = 0xFF1D,
+	/// CH3 wavelength, upper 3 bits.
+	Nr34 = 0xFF1E,
+	/// CH4 sound length.
+	Nr41 = 0xFF20,
+	/// CH4 volume control.
+	Nr42 = 0xFF21,
+	/// CH4 LFSR control.
+	Nr43 = 0xFF22,
+	/// CH4 control.
+	Nr44 = 0xFF23,
+	/// Master volume & VIN panning.
+	Nr50 = 0xFF24,
+	/// Sound panning.
+	Nr51 = 0xFF25,
+	/// Audio control.
+	Nr52 = 0xFF26,
+
+	Wave0 = 0xFF30,
+	Wave1 = 0xFF31,
+	Wave2 = 0xFF32,
+	Wave3 = 0xFF33,
+	Wave4 = 0xFF34,
+	Wave5 = 0xFF35,
+	Wave6 = 0xFF36,
+	Wave7 = 0xFF37,
+	Wave8 = 0xFF38,
+	Wave9 = 0xFF39,
+	WaveA = 0xFF3A,
+	WaveB = 0xFF3B,
+	WaveC = 0xFF3C,
+	WaveD = 0xFF3D,
+	WaveE = 0xFF3E,
+	WaveF = 0xFF3F,
+
+	/// LCD control.
+	Lcdc = 0xFF40,
+	/// LCD status.
+	Stat = 0xFF41,
+	/// Viewport vertical offset.
+	Scy = 0xFF42,
+	/// Viewport horizontal offset.
+	Scx = 0xFF43,
+	/// Current scanline.
+	Ly = 0xFF44,
+	/// LY comparison.
+	Lyc = 0xFF45,
+	/// OAM DMA source & start.
+	Dma = 0xFF46,
+	/// DMG background palette.
+	Bgp = 0xFF47,
+	/// DMG OBJ palette 0.
+	Obp0 = 0xFF48,
+	/// DMG OBJ palette 1.
+	Obp1 = 0xFF49,
+	/// Window Y coordinate.
+	Wy = 0xFF4A,
+	/// Window X coordinate.
+	Wx = 0xFF4B,
+
+	/// CGB speed switch.
+	Key1 = 0xFF4D,
+
+	/// CGB VRAM bank switch.
+	Vbk = 0xFF4F,
+
+	/// CGB DMA source, upper 8 bits.
+	Hdma1 = 0xFF51,
+	/// CGB DMA source, lower 8 bits.
+	Hdma2 = 0xFF52,
+	/// CGB DMA destination, upper 8 bits.
+	Hdma3 = 0xFF53,
+	/// CGB DMA destination, lower 8 bits.
+	Hdma4 = 0xFF54,
+	/// CGB DMA length & mode & start.
+	Hdma5 = 0xFF55,
+
+	/// CGB IR.
+	Rp = 0xFF56,
+
+	/// CGB BG palette address.
+	Bcps = 0xFF68,
+	/// CGB BG palette data.
+	Bcpd = 0xFF69,
+	/// CGB OBJ palette address.
+	Ocps = 0xFF6A,
+	/// CGB OBJ palette data.
+	Ocpd = 0xFF6B,
+
+	/// CGB WRAM bank switch.
+	Svbk = 0xFF70,
+
+	/// CH1 & CH2 digital output.
+	Pcm12 = 0xFF76,
+	/// CH3 & CH4 digital output.
+	Pcm34 = 0xFF77,
+
+	/// Enabled interrupts.
+	Ie = 0xFFFF,
+}
+
+impl From<HwReg> for u16 {
+	fn from(reg: HwReg) -> Self {
+		reg as u16
+	}
+}


### PR DESCRIPTION
Feat. a nice `#[derive(TryFrom)]` that I definitely didn't nerd-snipe myself into making. Nahhh.