### PR TITLE
Make optional deps of the binary only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,21 @@ repository = "https://github.com/eievui5/evunit"
 readme = "README.md"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-toml = { version = "0.5.9", features = ["preserve_order"] }
-clap = { version = "3.2.17", features = ["derive"] }
 paste = "1.0.9"
 thiserror = "1.0.37"
 try-from-discrim = "1.0.0"
 
+# For the binary
+clap = { version = "3.2.17", features = ["derive"], optional = true }
+toml = { version = "0.5.9", features = ["preserve_order"], optional = true }
+
+[features]
+evunit-bin = ["clap", "toml"]
+
 [profile.release]
 lto = true
+
+[[bin]]
+name = "evunit"
+required-features = ["evunit-bin"]


### PR DESCRIPTION
Avoids users of the lib pulling crates they don't need. I use `argh` instead of `clap`, for example.