### PR TITLE
correct treatment of stdin on all OSs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use gb_sym_file;
 use gb_cpu_sim::{cpu, memory};
 use paste::paste;
 
@@ -321,11 +320,15 @@ enum FailureReason {
 }
 
 fn main() {
-	fn open_input(path: &String) -> File {
-		File::open(if path == "-" { "/dev/stdin" } else { path }).unwrap_or_else(|msg| {
-			eprintln!("Failed to open {path}: {msg}");
-			exit(1)
-		})
+	fn open_input(path: &String) -> Box<dyn Read> {
+		if path == "-" {
+			Box::new(stdin())
+		} else {
+			Box::new(File::open(path).unwrap_or_else(|msg| {
+				eprintln!("Failed to open {path}: {msg}");
+				exit(1)
+			}))
+		}
 	}
 
 	let cli = Cli::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ enum FailureReason {
 fn main() {
 	fn open_input(path: &String) -> Box<dyn Read> {
 		if path == "-" {
-			Box::new(stdin())
+			Box::new(BufReader::new(stdin()))
 		} else {
 			Box::new(File::open(path).unwrap_or_else(|msg| {
 				eprintln!("Failed to open {path}: {msg}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use paste::paste;
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Error, Read, Write};
+use std::io::{stdin, BufRead, BufReader, Error, Read, Write};
 use std::process::exit;
 
 #[derive(Parser)]
@@ -534,7 +534,7 @@ impl memory::AddressSpace for AddressSpace {
 }
 
 impl AddressSpace {
-	pub fn open(mut file: File) -> Result<AddressSpace, Error> {
+	pub fn open<R: Read>(mut file: R) -> Result<AddressSpace, Error> {
 		let mut rom = Vec::<u8>::new();
 		file.read_to_end(&mut rom)?;
 		if rom.len() < 0x4000 {


### PR DESCRIPTION
this PR uses std::io::Stdin to handle input from stdin wherever it is required, no longer requiring a hack that only works on unix systems.