### PR TITLE
Bugfix of dump not actually showing memory contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.3 (2024-3-10)
+
+Fixed:
+- Dump not correctly showing contents of memory
+
 ## 1.3.2 (2024-3-3)
 
 New:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "evunit"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "clap",
  "gb-cpu-sim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evunit"
-version = "1.3.2"
+version = "1.3.3"
 description = "A unit testing program for the Game Boy"
 license = "MIT"
 homepage = "https://github.com/eievui5/evunit"

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -58,6 +58,7 @@ impl AddressSpace<'_> {
 	pub fn dump<W: Write>(&self, mut file: W) -> Result<(), Error> {
 		self.dump_memory("VRAM", 0x8000, &self.vram, &mut file)?;
 		self.dump_memory("WRAM", 0xC000, &self.wram, &mut file)?;
+		self.dump_memory("HRAM", 0xFF80, &self.hram, &mut file)?;
 
 		Ok(())
 	}

--- a/test/test.toml
+++ b/test/test.toml
@@ -61,3 +61,12 @@ a = 69
 [high-memory.result]
 a = 69
 b = 69
+
+# Test whether dump contains test values
+# It should be checked in the memory dump whether [wVariable] actually contains the given value
+[dump]
+pc = "OpcodeTest"
+a = 0
+"[wVariable]" = 0x55
+[dump.result]
+a = 10


### PR DESCRIPTION
Fixed issue mentioned at #32 regarding to dumps not actually showing memory contents. Confirming with the following test with `wVariable` being at address `$C000`:

```toml
[dump]
pc = "OpcodeTest"
a = 0
"[wVariable]" = 0x55
[dump.result]
a = 10
```

The dump now correctly shows the following:

```
[WRAM]
0xc000: 0x55 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
0xc010: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
0xc020: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
0xc030: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
0xc040: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
0xc050: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
...
```

I've also taken the liberty to pad the values to always be 2 digits long, to always have them aligned.
Additionally, I've also added the contents of HRAM to the dump.