### PR TITLE
Display register errors in hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can either assign an 8-bit integer, a string, or an array of either.
 stack = [ 0x04, 0x71, 0xff, "\n" ]
 ```
 
-Due note that values are pushed to the stack in reverse.
+Do note that values are pushed to the stack in reverse.
 As an example, the initial values on the stack for the example above look like the following (assuming `sp` = `0xD000`):
 
 ```

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -35,6 +35,28 @@ impl fmt::Display for CompareResult {
 	}
 }
 
+trait FormatValue {
+	fn format_value(&self) -> String;
+}
+
+impl FormatValue for bool {
+	fn format_value(&self) -> String {
+		self.to_string()
+	}
+}
+
+impl FormatValue for u8 {
+	fn format_value(&self) -> String {
+		format!("{:#04X}", self)
+	}
+}
+
+impl FormatValue for u16 {
+	fn format_value(&self) -> String {
+		format!("{:#04X}", self)
+	}
+}
+
 // All of these parameters are optional. This is because the initial values as
 // well as the resulting values do not all need to be present, and in the case
 // of results, may even be unknown.
@@ -131,8 +153,8 @@ impl Registers {
 					if $cpu != value {
 						errors.contents.push((
 							CompareSource::Register(stringify!($name)),
-							$cpu.to_string(),
-							value.to_string()
+							$cpu.format_value(),
+							value.format_value()
 						))
 					}
 				}


### PR DESCRIPTION
I've been learning Gameboy assembler and have found this to be very useful in testing my code, but I think being able to see these values in hex format would be useful.

The test suite I've been using now looks like this:

```
build/bouncy-bop.gb: GetTileByPixel-0x0 passed
build/bouncy-bop.gb: GetTileByPixel-8x0 passed
build/bouncy-bop.gb: GetTileByPixel-0x8 failed:
hl (0x9821) does not match expected value (0x9820)
build/bouncy-bop.gb: GetTileByPixel-8x8 passed
build/bouncy-bop.gb: GetTileByPixel-1 failed:
hl (0x9820) does not match expected value (0x9904)
build/bouncy-bop.gb: GetTileByPixel-2 failed:
hl (0x98EA) does not match expected value (0x992F)
build/bouncy-bop.gb: All tests complete. 3/6 passed.
```