### PR TITLE
Use owo-colors for color output #8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "clap",
  "gb-cpu-sim",
  "gb-sym-file",
+ "owo-colors",
  "paste",
  "serde",
  "thiserror",
@@ -160,6 +161,12 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "paste"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 clap = { version = "4.4.6", features = ["derive"] }
 gb-cpu-sim = "1.0.0"
 gb-sym-file = "1.0.1"
+owo-colors = "4.2.0"
 paste = "1.0.9"
 serde = "1.0.197"
 thiserror = "1.0.49"

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use gb_cpu_sim::{cpu, memory};
-use owo_colors::{OwoColorize, Style};
+use owo_colors::OwoColorize;
 
 use crate::test::{FailureReason, TestConfig};
 
@@ -55,31 +55,18 @@ impl<'a> Logger<'a> {
 	pub fn finish(&self) -> bool {
 		// When in SILENCE_ALL only print the final message if a test failed.
 		if !self.silence_all || self.failure != 0 {
-			let total = self.pass + self.failure;
-			let style: Style = if total == 0 {
-				Style::new().yellow()
-			} else if self.pass == total {
-				Style::new().green()
-			} else if self.pass == 0 {
-				Style::new().red()
-			} else {
-				Style::new().yellow()
-			};
-
 			println!(
-				"{}{} {}/{} {}",
-				self.rom_path.style(style),
-				": All tests complete.".style(style),
-				self.pass.style(style),
-				(self.pass + self.failure).style(style),
-				"passed.".style(style)
+				"{}: All tests complete. {}/{} passed.",
+				self.rom_path,
+				self.pass,
+				self.pass + self.failure,
 			);
 		}
 		self.failure == 0
 	}
 }
 
-impl<'a, 'b> TestLogger<'a, 'b> {
+impl TestLogger<'_, '_> {
 	pub fn log_breakpoint<A: memory::AddressSpace>(&mut self, cpu_state: &cpu::State<A>) {
 		if self.enable_breakpoints {
 			println!(
@@ -100,8 +87,8 @@ impl<'a, 'b> TestLogger<'a, 'b> {
 		if !self.logger.silence_passing {
 			println!(
 				"{}: {} {}",
-				self.logger.rom_path.green(),
-				self.name.green(),
+				self.logger.rom_path,
+				self.name,
 				"passed".green()
 			);
 		}
@@ -114,13 +101,13 @@ impl<'a, 'b> TestLogger<'a, 'b> {
 	) {
 		println!(
 			"{}: {} {}:\n{}\n{}",
-			self.logger.rom_path.red(),
-			self.name.red(),
+			self.logger.rom_path,
+			self.name,
 			"failed".red(),
 			match failure_reason {
-				FailureReason::InvalidOpcode => "Invalid opcode".red(),
-				FailureReason::Crash => "Crashed".red(),
-				FailureReason::Timeout => "Timeout".red(),
+				FailureReason::InvalidOpcode => "Invalid opcode",
+				FailureReason::Crash => "Crashed",
+				FailureReason::Timeout => "Timeout",
 			},
 			cpu_state
 		);
@@ -129,9 +116,9 @@ impl<'a, 'b> TestLogger<'a, 'b> {
 	pub fn incorrect(&mut self, msg: &Error) {
 		print!(
 			"{}: {} {}:\n{}",
-			self.logger.rom_path.red(),
+			self.logger.rom_path,
+			self.name,
 			"failed".red(),
-			self.name.red(),
 			msg,
 		);
 		self.logger.failure += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,12 +94,8 @@ fn read_config(path: &str, symfile: &HashMap<String, (u32, u16)>) -> Vec<TestCon
 		if let Some((_, address)) = symfile.get(address) {
 			// Attempt to get address from symfile
 			Some(*address)
-		} else if let Ok(address) = u16::deserialize(toml::de::ValueDeserializer::new(address)) {
-			// Attempt to parse address as an u16 value
-			Some(address)
 		} else {
-			// Failed to parse address
-			None
+			u16::deserialize(toml::de::ValueDeserializer::new(address)).ok()
 		}
 	}
 
@@ -107,7 +103,7 @@ fn read_config(path: &str, symfile: &HashMap<String, (u32, u16)>) -> Vec<TestCon
 		match value {
 			toml::Value::Integer(value) => {
 				if *value > 255 || *value < -128 {
-					let value_array = (*value as i64)
+					let value_array = value
 						.to_le_bytes()
 						.iter()
 						.skip_while(|b| **b == 0)
@@ -265,7 +261,8 @@ fn read_config(path: &str, symfile: &HashMap<String, (u32, u16)>) -> Vec<TestCon
 								if let (Some((_, '[')), Some((begin, _)), Some((end, ']'))) =
 									(indices.next(), indices.next(), indices.last())
 								{
-									match parse_memory_assignment(&key[begin..end], value, symfile) {
+									match parse_memory_assignment(&key[begin..end], value, symfile)
+									{
 										Err(cause) => eprintln!("{}", cause),
 										Ok(data) => result.memory = data,
 									};

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -2,6 +2,7 @@ use crate::{Error, Result};
 use gb_cpu_sim::{cpu, memory};
 use paste::paste;
 use std::fmt;
+use owo_colors::OwoColorize;
 
 #[derive(Clone, Debug)]
 enum CompareSource {
@@ -28,7 +29,10 @@ impl fmt::Display for CompareResult {
 		for (source, result, expected) in &self.contents {
 			writeln!(
 				f,
-				"{source} ({result}) does not match expected value ({expected})"
+				"{source} ({result}) does not match expected value ({expected})",
+				source = source.bold().bright_white(),
+				result = result.cyan(),
+				expected = expected.cyan()
 			)?;
 		}
 		Ok(())

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -2,7 +2,6 @@ use crate::{Error, Result};
 use gb_cpu_sim::{cpu, memory};
 use paste::paste;
 use std::fmt;
-use owo_colors::OwoColorize;
 
 #[derive(Clone, Debug)]
 enum CompareSource {
@@ -30,9 +29,6 @@ impl fmt::Display for CompareResult {
 			writeln!(
 				f,
 				"{source} ({result}) does not match expected value ({expected})",
-				source = source.bold().bright_white(),
-				result = result.cyan(),
-				expected = expected.cyan()
 			)?;
 		}
 		Ok(())


### PR DESCRIPTION
Utilize `owo-colors` for color output and colorize a little more of the output.

Example:
![image](https://github.com/user-attachments/assets/3f3e9f44-9f0c-477f-9f4a-016099e90212)